### PR TITLE
Add License to gemspec

### DIFF
--- a/attr_required.gemspec
+++ b/attr_required.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.summary = %q{attr_required and attr_optional}
   s.email = "nov@matake.jp"
   s.extra_rdoc_files = ["LICENSE", "README.rdoc"]
+  s.license = 'MIT'
   s.rdoc_options = ["--charset=UTF-8"]
   s.homepage = "http://github.com/nov/attr_required"
   s.require_paths = ["lib"]


### PR DESCRIPTION
This increases the discoverability of what license this gem uses. See rubygems/rubygems.org#363 or [this blog post](http://www.benjaminfleischer.com/2013/07/12/make-the-world-a-better-place-put-a-license-in-your-gemspec/) for more info.
