### PR TITLE
⚠️ `*' interpreted as argument prefix

### DIFF
--- a/lib/attr_optional.rb
+++ b/lib/attr_optional.rb
@@ -9,16 +9,16 @@ module AttrOptional
     def inherited(klass)
       super
       unless optional_attributes.empty?
-        klass.attr_optional *optional_attributes
+        klass.attr_optional(*optional_attributes)
       end
     end
 
     def attr_optional(*keys)
       if defined? undef_required_attributes
-        undef_required_attributes *keys
+        undef_required_attributes(*keys)
       end
       optional_attributes.concat(keys)
-      attr_accessor *keys
+      attr_accessor(*keys)
     end
 
     def attr_optional?(key)

--- a/lib/attr_required.rb
+++ b/lib/attr_required.rb
@@ -11,16 +11,16 @@ module AttrRequired
     def inherited(klass)
       super
       unless required_attributes.empty?
-        klass.attr_required *required_attributes
+        klass.attr_required(*required_attributes)
       end
     end
 
     def attr_required(*keys)
       if defined? undef_optional_attributes
-        undef_optional_attributes *keys
+        undef_optional_attributes(*keys)
       end
       required_attributes.concat keys
-      attr_accessor *keys
+      attr_accessor(*keys)
     end
 
     def attr_required?(key)


### PR DESCRIPTION
Here's a patch that eliminates some Ruby warnings concerning `*` literal ambiguity.