### PR TITLE
Use HTTPS in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 gemspec


### PR DESCRIPTION
Products like Sonatype Nexus Repo are flagging attr_required as being "vulnerable to a Man-in-the-Middle attack" due to the HTTP here. Making this HTTPS will solve the issue being reported and allow more secure facilities to use this module without being flagged.